### PR TITLE
削除機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create, :edit, :update]
-  before_action :set_item, only: [:show, :edit, :update]
-  before_action :move_to_root, only: [:edit, :update]
+  before_action :authenticate_user!, only: [:new, :create, :edit, :destroy]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
+  before_action :move_to_root, only: [:edit, :update, :destroy]
 
   def index
     @items = Item.order(created_at: :desc)
@@ -32,6 +32,11 @@ class ItemsController < ApplicationController
     else
       render :edit, status: :unprocessable_entity
     end
+  end
+
+  def destroy
+    @item.destroy
+    redirect_to root_path
   end
 
   private

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -29,7 +29,10 @@
         <%# ログインユーザーと出品者が同じ場合 %>
         <%= link_to "商品の編集", edit_item_path(@item), class: "item-red-btn" %>
         <p class="or-text">or</p>
-        <%= link_to "削除", "#", class:"item-destroy" %>
+        <%= link_to "削除", item_path(@item),
+                data: { turbo_method: :delete },
+                class: "item-destroy" %>
+
       <% else %>
         <%# ログインユーザーと出品者が違う、かつ、未購入の場合 %>
         <%# 🔜 購入機能実装後、売却済み商品の場合は下記を非表示 %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
   
   root "items#index"
-  resources :items, only: [:index, :new, :create, :show, :edit, :update]
+  resources :items, only: [:index, :new, :create, :show, :edit, :update, :destroy]
 end


### PR DESCRIPTION
What

商品詳細ページから、ログイン中の出品者のみが商品の削除を行える機能を実装しました。

Why

ユーザーが自身の出品した商品を管理できるようにするため。また、他ユーザーによる不正な削除を防ぐため、コントローラ側にもアクセス制限を追加する必要があるため。

# プルリクエストへ記載するgyazo　ご確認のほどよろしくお願いいたします。

ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
 [https://gyazo.com/cbdc691c9e6c491e8b2d478b69fefdc6 ] 
